### PR TITLE
Token cannot pass to websockify

### DIFF
--- a/spice_auto.html
+++ b/spice_auto.html
@@ -127,6 +127,9 @@
                 }
 
                 uri = scheme + host + ":" + port;
+                if (token) {
+                    uri = uri + "/?token=" + token;
+                }
 
                 try
                 {


### PR DESCRIPTION
Fix the issue: https://github.com/kanaka/websockify/issues/213.
When the websockify use --token-plugin, the spice_auto.html cannot pass the token value to websockify. Because websockfiy use the path, but the path variable is useless in spice_auto.html. So i added the token to the uri if token is not empty.
